### PR TITLE
Resolve memory leak during Wayland recording using Xwayland #4247

### DIFF
--- a/src/audacity.desktop.in
+++ b/src/audacity.desktop.in
@@ -61,7 +61,7 @@ Categories=AudioVideo;Audio;AudioVideoEditing;
 
 Keywords=sound;music editing;voice channel;frequency;modulation;audio trim;clipping;noise reduction;multi track audio editor;edit;mixing;WAV;AIFF;FLAC;MP2;MP3;
 
-Exec=env UBUNTU_MENUPROXY=0 @AUDACITY_NAME@ %F
+Exec=env GDK_BACKEND=x11 UBUNTU_MENUPROXY=0 @AUDACITY_NAME@ %F
 StartupNotify=false
 Terminal=false
 MimeType=@MIMETYPES@;


### PR DESCRIPTION
Resolves: #4247

Add GDK_BACKEND=x11 to Exec env
Resolve memory leak during Wayland recording using Xwayland 

<!-- Use "x" to fill the checkboxes below like [x] -->

- [x] I signed [CLA](https://www.audacityteam.org/cla/)
- [x] The title of the pull request describes an issue it addresses
- [x] If changes are extensive, then there is a sequence of easily reviewable commits
- [x] Each commit's message describes its purpose and effects
- [x] There are no behavior changes unnecessary for the stated purpose of the PR

Recommended:
- [ ] Each commit compiles and runs on my machine without known undesirable changes of behavior